### PR TITLE
Add support for translations in checkout by obtaining locales correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
   "name": "shopify-theme-lab-plugins",
-  "private": "true"
+  "private": "true",
+  "devDependencies": {
+    "@types/node": "^18.11.18"
+  }
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -25,6 +25,7 @@
     "cross-env": "^7.0.3",
     "rollup": "^2.52.1",
     "rollup-plugin-delete": "^2.0.0",
-    "typescript": "^4.3.4"
+    "typescript": "^4.3.4",
+    "tslib": "^2.4.1"
   }
 }

--- a/packages/i18n/src/modules/i18n.ts
+++ b/packages/i18n/src/modules/i18n.ts
@@ -9,7 +9,7 @@ export class I18n {
   readonly locale: string
 
   constructor (options?: I18nOptions) {
-    this.locale = window.Shopify.locale || options?.fallbackLocale || 'en'
+    this.locale = window.Shopify.locale || window.Shopify.Checkout?.normalizedLocale || options?.fallbackLocale || 'en'
     this.translations = this._loadTranslations()
     this.$t = this.$t.bind(this)
   }

--- a/packages/i18n/src/types/global.ts
+++ b/packages/i18n/src/types/global.ts
@@ -1,6 +1,9 @@
 interface Window {
   Shopify: {
-    locale: string
+    locale: string,
+    Checkout: {
+      normalizedLocale: string
+    }
   }
 }
 


### PR DESCRIPTION
For Shopify Plus stores where checkout can be modified via checkout.liquid, the module does not work correctly.  Reason is that locale is obtained using `window.Shopify.locale` but in checkout locales is located in `window.Shopify.Checkout.normalizedLocale`

This PR adds support to adding translations to Vue components added to checkout.liquid